### PR TITLE
Better sector/track calculations

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 
 // For calculating sector at a position in the spiral track/groove
-inline int trackToSector(const int track) { return pow(track, 2) * 0.00031499 + track * 9.357516535; }
+inline int trackToSector(int track) { return (int)(((int64_t)track * 642889 + ((int64_t)track * (track - 1) * 21))>>16); }
 
 inline int sectorsPerTrack(const int track) { return round(track * 0.000616397 + 9); }


### PR DESCRIPTION
I have changed the track and sector data calculations to increase stability. This formula came from a few steps. First, i started from scratch, took the values of disc dimension, sector length, track width, etc to recalculate the value. Second, i simplified the formulas to speed up. Lastly, i have converted it from float calculations to 16.16 fixed point integer calculations. It became more stable and accurate. With this update, Resident Evil 3 intro sound plays for example.